### PR TITLE
Add background-color to CSS

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -5,6 +5,7 @@
  */
 html {
   overflow-y: scroll;
+  background-color: white;
 }
 
 element {


### PR DESCRIPTION
The default background color can be set in most browsers. If the user chooses a dark color there, patricksimpson.me becomes unreadable.

Before:

![screenshot_2020-06-02T12-25-41](https://user-images.githubusercontent.com/3681516/83509901-7287af80-a4cc-11ea-8be4-c0b3898140f6.png)

After:

![screenshot_2020-06-02T12-26-32](https://user-images.githubusercontent.com/3681516/83509902-7287af80-a4cc-11ea-92d3-983b50661d1d.png)
